### PR TITLE
Added async attribute for fragment's script

### DIFF
--- a/packages/fabricsjs/src/index.js
+++ b/packages/fabricsjs/src/index.js
@@ -13,7 +13,7 @@ const renderFragment = (html, preloadedState, fragmentName, jsFileName) => {
         <script>
           window.${getStateName(fragmentName)} = ${JSON.stringify(preloadedState).replace(/</g, '\\x3c')}
         </script>
-        <script src="${config.assetHost}/${config.assetPrefix}/${jsFileName}"></script>
+        <script async src="${config.assetHost}/${config.assetPrefix}/${jsFileName}"></script>
       </body>
      <html>`
 }


### PR DESCRIPTION
If you are using synchronous script tag and it requires some time to be fully downloaded your page rendering process will be blocked. Browser will be waiting while a script will be downloaded and only then will continue rendering process. Instead of that we can use `async` attribute, so it will prevent blocking behaviour. If you need, i can provide POC.